### PR TITLE
fix: find all exact matches for reserved file names

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -38,9 +38,9 @@ git diff --cached --name-only --diff-filter=A -z $against | while IFS= read -r -
   # We don't test for / (forward slash) here as that is even on *nix not allowed in *filename*
   illegalchars=$(echo -n "$filename" | LC_ALL=C grep -E '(<|>|:|"|\\|\||\?|\*)' | wc -c)
 
-  # Reserved names plus possible extension
+  # Reserved names, accounting for possible extension
   # CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9
-  reservednames=$(echo -n "$filename" | LC_ALL=C grep -i -E '(CON|PRN|AUX|NUL|COM1|COM2|COM3|COM4|COM5|COM6|COM7|COM8|COM9|LPT1|LPT2|LPT3|LPT4|LPT5|LPT6|LPT7|LPT8|LPT9).[a-z]{3}' | wc -c)
+  reservednames=$(echo -n "$filename" | LC_ALL=C grep -i -E '(^|/)(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\.|$)' | wc -c)
 
   # No trailing period or space
   trailingperiodorspace=$(echo -n "$filename" | LC_ALL=C grep -E '(\.| )$' | wc -c)

--- a/test-hook.sh
+++ b/test-hook.sh
@@ -17,13 +17,15 @@ checkname ()
   
   filename="$1"
   counter=$(expr $counter \+ 1)
+  mkdir -p "$(dirname "$filename")" &&
   touch "$filename" &&
   git add "$filename" &&
   GIT_TRACE=1 git commit -m "my message"
   ret=$?
   git reset --hard $commit > /dev/null
 
-  if test $ret -eq 1
+  expected_exit_code=${2:-1}
+  if test $ret -eq $expected_exit_code
   then
     echo "Test $counter passed"
   else
@@ -50,6 +52,10 @@ echo "###reserved names###"
 checkname "CON.txt" 
 checkname "AUX.txt" 
 checkname "LPT1.txt" 
+checkname "COM1"
+checkname "NUL"
+checkname "sub/folder/PRN"
+checkname "comic-con.txt" 0
 
 echo "###no trailing period or space###"
 checkname " "


### PR DESCRIPTION
Up until now, the regex only matched files with an extension,
(e.g. NUL.txt), which is probably the less common mistake.
Furthermore, whenever a file ended with a reserved name (e.g. COMICCON.txt),
it could not be added either.
I came up with a regex that solves these problems and is closer to the comments
on the StackOverflow thread that the script refers to.